### PR TITLE
Fix #57 fix: change tool name to get_repo_contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Github Second Brain provides AI assistants with several valuable tools to help t
 
 - **When it's useful:** For questions about the structure of the repositories.
 
-### `get_file_contents`
+### `get_repo_contents`
 
 - This tool returns full content of any files/directories existing in the repository.
 

--- a/mcp/main.py
+++ b/mcp/main.py
@@ -72,7 +72,7 @@ async def get_directory_tree(
     
 
 @mcp.tool()
-async def get_file_contents(
+async def get_repo_contents(
     owner: str,
     repo: str,
     path: str = "",


### PR DESCRIPTION
## Describe your changes (Include screenshots if neccessary)
change tool name from `get_file_contents` to `get_repo_contents` in `main.py` and `README.md`

## Issue ticket number and link
Closes #57

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the doc accordingly
